### PR TITLE
Trigger change event on original select

### DIFF
--- a/src/javascript/vanilla-js-dropdown.js
+++ b/src/javascript/vanilla-js-dropdown.js
@@ -89,6 +89,10 @@ var CustomSelect = function(options) {
             selectContainer.querySelector('.' + titleClass).innerText = t.innerText;
             elem.options.selectedIndex = t.getAttribute('data-index');
 
+            //trigger 'change' event
+            var evt = new Event('change');
+            elem.dispatchEvent(evt);
+
             // highlight the selected
             for (var i = 0; i < optionsLength; i++) {
                 ul.querySelectorAll('li')[i].classList.remove(selectedClass);


### PR DESCRIPTION
This enables developers to listen to 'change' events on the original `select` element (`elem`), because they aren't automatically triggered when `selectedIndex` is changed programatically.