### PR TITLE
Use CustomEvent instead of Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Chrome | yes | -
 Firefox | yes | -
 Safari | yes | -
 Opera | yes | -
-IE & Edge | yes* | [Polyfill](//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js) for `.classList` in IE9
+Edge | yes | -
+IE | yes* | [Polyfill](//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js) for `.classList` in IE9, [Polyfill](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill) for CustomEvent in IE9+
 
 \* _IE9 and up_
 

--- a/src/javascript/vanilla-js-dropdown.js
+++ b/src/javascript/vanilla-js-dropdown.js
@@ -94,7 +94,7 @@ var CustomSelect = function(options) {
             elem.options.selectedIndex = t.getAttribute('data-index');
 
             //trigger 'change' event
-            var evt = new Event('change');
+            var evt = new CustomEvent('change');
             elem.dispatchEvent(evt);
 
             // highlight the selected


### PR DESCRIPTION
Hey there 👋 

As far as I have seen `vanilla-js-dropdown` doesn't work in IE at the moment because it uses `Event` which is not supported. This PR changes it to use `CustomEvent` which can be brought to IE using a polyfill:

https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
https://www.npmjs.com/package/custom-event-polyfill