### PR TITLE
Fix selected option handling

### DIFF
--- a/src/javascript/vanilla-js-dropdown.js
+++ b/src/javascript/vanilla-js-dropdown.js
@@ -140,5 +140,3 @@ var CustomSelect = function(options) {
         open:   open
     };
 };
-
-export default CustomSelect;

--- a/src/javascript/vanilla-js-dropdown.js
+++ b/src/javascript/vanilla-js-dropdown.js
@@ -19,7 +19,7 @@ var CustomSelect = function(options) {
         listClass     = 'js-Dropdown-list',
         selectedClass = 'is-selected',
         openClass     = 'is-open',
-        selectOptions = elem.querySelectorAll('option'),
+        selectOptions = elem.options,
         optionsLength = selectOptions.length;
 
     // creating the pseudo-select container

--- a/src/javascript/vanilla-js-dropdown.js
+++ b/src/javascript/vanilla-js-dropdown.js
@@ -48,7 +48,7 @@ var CustomSelect = function(options) {
         li.setAttribute('data-value', selectOptions[i].value);
         li.setAttribute('data-index', i);
 
-        if (selectOptions[i].getAttribute('selected') !== null) {
+        if (elem.selectedIndex === i) {
             li.classList.add(selectedClass);
             button.textContent = selectOptions[i].textContent;
         }

--- a/src/javascript/vanilla-js-dropdown.js
+++ b/src/javascript/vanilla-js-dropdown.js
@@ -140,3 +140,5 @@ var CustomSelect = function(options) {
         open:   open
     };
 };
+
+export default CustomSelect;


### PR DESCRIPTION
Hey there!

When refreshing a page or navigating back, the `selected` attribute on the previously selected option isn't being set by the browser. This changes it to use `selectedIndex` on the `select` element which always returns the selected option. Also includes a small optimization.

Let me know what you think 🙂 