### PR TITLE
Add isOpen class toggle for parent container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /node_modules
 /coverage
+
+# IntellijIDEA project files
+.idea/

--- a/src/javascript/vanilla-js-dropdown.js
+++ b/src/javascript/vanilla-js-dropdown.js
@@ -140,6 +140,7 @@ var CustomSelect = function(options) {
    * @public
    */
   function toggle() {
+    selectContainer.classList.toggle(openClass);
     ul.classList.toggle(openClass);
   }
 
@@ -149,6 +150,7 @@ var CustomSelect = function(options) {
    * @public
    */
   function open() {
+    selectContainer.classList.add(openClass);
     ul.classList.add(openClass);
   }
 
@@ -158,6 +160,7 @@ var CustomSelect = function(options) {
    * @public
    */
   function close() {
+    selectContainer.classList.remove(openClass);
     ul.classList.remove(openClass);
   }
 


### PR DESCRIPTION
Actually, this PR is similar to @doubleedesign PR (https://github.com/zoltantothcom/vanilla-js-dropdown/pull/48) except this one is toggles parent's CSS-class 'is-open' on dropdown